### PR TITLE
fix: not only vectors are sorted

### DIFF
--- a/src/clj/big_config/utils.clj
+++ b/src/clj/big_config/utils.clj
@@ -15,7 +15,7 @@
                    (for [[k v] m]
                      [k (cond
                           (map? v) (nested-sort-map v)
-                          (vector? v) (mapv nested-sort-map v)
+                          (seq? v) (mapv nested-sort-map v)
                           :else v)]))
-    (vector? m) (mapv nested-sort-map m)
+    (seq? m) (mapv nested-sort-map m)
     :else m))

--- a/src/clj/big_config/utils.clj
+++ b/src/clj/big_config/utils.clj
@@ -15,7 +15,7 @@
                    (for [[k v] m]
                      [k (cond
                           (map? v) (nested-sort-map v)
-                          (seq? v) (mapv nested-sort-map v)
+                          (or (vector? v) (seq? v)) (mapv nested-sort-map v)
                           :else v)]))
-    (seq? m) (mapv nested-sort-map m)
+    (or (vector? m) (seq? m)) (mapv nested-sort-map m)
     :else m))


### PR DESCRIPTION
Small fix that also sorts other collection types (LazySeq, List)